### PR TITLE
Fix path to header

### DIFF
--- a/include/bindings.h
+++ b/include/bindings.h
@@ -1,1 +1,1 @@
-#include <boolector/boolector.h>
+#include <boolector.h>


### PR DESCRIPTION
Changed path to `boolector.h`, according to example from [Boolector documentation](https://boolector.github.io/docs/cboolector.html#internals).