### PR TITLE
Update boolector and regenerate bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 Cargo.lock
+**/*~
+**/.*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license                                 = "MIT"
 name                                    = "boolector-sys"
 readme                                  = "README.md"
 repository                              = "https://github.com/fatemender/boolector-sys"
-version                                 = "0.3.0"
+version                                 = "0.3.1"
 
 [dependencies]
 libc                                    = "0.2"

--- a/src-generated/bindings.rs
+++ b/src-generated/bindings.rs
@@ -397,6 +397,14 @@ extern "C" {
     ) -> *mut BoolectorNode;
 }
 extern "C" {
+    pub fn boolector_const_array(
+        btor: *mut Btor,
+        sort: BoolectorSort,
+        value: *mut BoolectorNode,
+        symbol: *const ::std::os::raw::c_char,
+    ) -> *mut BoolectorNode;
+}
+extern "C" {
     pub fn boolector_uf(
         btor: *mut Btor,
         sort: BoolectorSort,
@@ -948,6 +956,9 @@ extern "C" {
 }
 extern "C" {
     pub fn boolector_is_fun_sort(btor: *mut Btor, sort: BoolectorSort) -> bool;
+}
+extern "C" {
+    pub fn boolector_bitvec_sort_get_width(btor: *mut Btor, sort: BoolectorSort) -> u32;
 }
 extern "C" {
     pub fn boolector_parse(


### PR DESCRIPTION
This PR updates the boolector submodule to commit `b9827374` and regenerates the bindings appropriately.  This results in adding two new functions to the bindings.

I've taken the liberty of including a commit to bump the crate version to 0.3.1 in this PR.  The changes shouldn't be breaking since the only change to the bindings is adding new functions.  Feel free to remove that commit if you don't want the version increment yet.