### PR TITLE
build.rs: link with lgl

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
 fn main() {
     println!("cargo:rustc-link-lib=boolector");
+    println!("cargo:rustc-link-lib=lgl");
 }


### PR DESCRIPTION
I think we need this additional command in build.rs in order to link with the `lgl` (Lingeling) library.  I've needed this all along, and just assumed it was a peculiarity of my machine; but I've now found that on multiple machines and in multiple environments I need this flag.  I'm using Boolector's default installation instructions, which set up Lingeling as the underlying solver.