### PR TITLE
Fix: Execute vendor build in OUT_DIR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository                              = "https://github.com/fatemender/boolect
 version                                 = "0.6.1"
 
 [features]
-vendor-lgl                              = ["cc", "cmake"]
+vendor-lgl                              = ["cc", "cmake", "copy_dir"]
 
 [dependencies]
 libc                                    = "0.2.73"
@@ -23,3 +23,4 @@ libc                                    = "0.2.73"
 [build-dependencies]
 cc                                      = { version = "1.0", optional = true }
 cmake                                   = { version = "0.1", optional = true }
+copy_dir                                = { version = "0.1.2", optional = true }

--- a/build-vendor.rs
+++ b/build-vendor.rs
@@ -1,16 +1,14 @@
 use cmake::Config;
+use copy_dir::copy_dir;
 use std::{
-    env, fs,
+    env,
     path::{Path, PathBuf},
     process::Command,
 };
 
-pub fn source_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("boolector")
-}
-
 pub struct Build {
-    out_dir: Option<PathBuf>,
+    source_dir: PathBuf,
+    out_dir: PathBuf,
 }
 
 pub struct Artifacts {
@@ -22,43 +20,54 @@ pub struct Artifacts {
 impl Build {
     pub fn new() -> Build {
         Build {
-            out_dir: env::var_os("OUT_DIR").map(|s| PathBuf::from(s).join("boolector-build")),
+            source_dir: Path::new(env!("CARGO_MANIFEST_DIR")).join("boolector"),
+            out_dir: PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR not set"))
+                .join("vendor-build"),
         }
     }
 
     pub fn prerequisites(&mut self) -> &mut Self {
-        // TODO: Move everything to out_dir
+        // it is not allowed to modify files outside of OUT_DIR,
+        // so everything has to be copied to OUT_DIR before the build can be started
+        if !self.out_dir.exists() {
+            copy_dir(&self.source_dir, &self.out_dir)
+                .expect("Unable to copy Boolector sources to OUT_DIR");
+        }
 
-        if !source_dir().join("deps/install/lib/liblgl.a").exists() {
+        if !self.out_dir.join("deps/install/lib/liblgl.a").exists() {
             self.run_command(
                 Command::new("/usr/bin/env")
                     .arg("bash")
-                    .arg(source_dir().join("contrib/setup-lingeling.sh"))
-                    .current_dir(&source_dir()),
+                    .arg(self.out_dir.join("contrib/setup-lingeling.sh"))
+                    .current_dir(&self.out_dir),
                 "Setup Lingeling",
             );
         }
 
         println!(
             "cargo:rustc-link-search=native={}",
-            source_dir().join("deps/install/lib").display()
+            self.out_dir.join("deps/install/lib").display()
         );
         println!("cargo:rustc-link-lib=static=lgl");
         println!(
             "cargo:include={}",
-            source_dir().join("deps/install/include").display()
+            self.out_dir.join("deps/install/include").display()
         );
         println!(
             "cargo:lib={}",
-            source_dir().join("deps/install/lib").display()
+            self.out_dir.join("deps/install/lib").display()
         );
 
-        if !source_dir().join("deps/install/lib/libbtor2parser.a").exists() {
+        if !self
+            .out_dir
+            .join("deps/install/lib/libbtor2parser.a")
+            .exists()
+        {
             self.run_command(
                 Command::new("/usr/bin/env")
                     .arg("bash")
-                    .arg(source_dir().join("contrib/setup-btor2tools.sh"))
-                    .current_dir(&source_dir()),
+                    .arg(self.out_dir.join("contrib/setup-btor2tools.sh"))
+                    .current_dir(&self.out_dir),
                 "Setup btor2tools",
             );
         }
@@ -69,20 +78,7 @@ impl Build {
     pub fn build(&mut self) -> Artifacts {
         // TODO: Unfortunately BUILDDIR is not overwriteable either implement
         // whole `Configure.sh` or find out how to overwrite `$BUILDDIR`
-
-        let out_dir = self.out_dir.as_ref().expect("OUT_DIR not set");
-        let build_dir = out_dir.join("build");
-        let install_dir = out_dir.join("install");
-
-        if build_dir.exists() {
-            fs::remove_dir_all(&build_dir).unwrap();
-        }
-
-        if install_dir.exists() {
-            fs::remove_dir_all(&install_dir).unwrap();
-        }
-
-        let target_dir = Config::new(source_dir()).build();
+        let target_dir = Config::new(&self.out_dir).build();
 
         Artifacts {
             lib_dir: target_dir.join("lib"),


### PR DESCRIPTION
As described [here](https://docs.rs/about/builds), docs.rs builds will fail for crates, which attempt to write into read-only directories. The problem is, that (with feature `vendor-lgl`) the Boolector build is executed in a read-only directory at the moment.

As a result of that, our build of our crate fails on docs.rs. (https://docs.rs/crate/monster-rs/0.1.0)

This PR fixes that, by moving all of the Boolector sources into the OUT_DIR first, and build it in that directory.