### PR TITLE
use build_target() instead of target()

### DIFF
--- a/build-vendor.rs
+++ b/build-vendor.rs
@@ -80,7 +80,7 @@ impl Build {
         // whole `Configure.sh` or find out how to overwrite `$BUILDDIR`
         let target_dir = Config::new(&self.out_dir)
             .profile("Release")
-            .target("boolector")
+            .build_target("boolector")
             .build();
 
         Artifacts {


### PR DESCRIPTION
Hi. The build function uses `target()` in cmake (which allows to set the target triple but not the build target: https://github.com/rust-lang/cmake-rs/blob/master/src/lib.rs#L287).

When using cmake v3.28.3 and clang on mac, this causes the compile command to contain `--target=boolector`, resulting in a compile error (`error: unknown target triple 'boolector', please use -triple or -arch`).

To fix this, we can chain it with `build_target("boolector")` instead of `target("boolector")`.